### PR TITLE
Add conda-lock 1.4.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,23 +9,23 @@ source:
   sha256: 55c115a852e63395db8a6a90cf2892aab0543959f2d0bafb83158b6863831b8a
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
-  noarch: python
+  number: 0
+  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   entry_points:
     - conda-lock = conda_lock:main
 
 requirements:
   host:
-    - python >=3.6
-    - pip
-    - setuptools >=41.2
-    - setuptools-scm
+    - python
     - hatch
     - hatch-requirements-txt
     - hatch-vcs
+    - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - cachecontrol-with-filecache >=0.12.9
     - cachy >=0.3.0
     - click >=8.0
@@ -33,8 +33,9 @@ requirements:
     - clikit >=0.6.2
     - crashtest >=0.3.0
     - ensureconda >=1.3
+    - filelock >=3.8.0
     - html5lib >=1.0
-    - importlib-metadata >=1.7.0
+    - importlib-metadata >=1.7.0  # [py<38]
     - jinja2
     - keyring >=21.2.0
     - packaging >=20.4
@@ -43,7 +44,7 @@ requirements:
     - pyyaml >=5.1
     - requests >=2.18
     - ruamel.yaml
-    - tomli
+    - tomli  # [py<311]
     - tomlkit >=0.7.0
     - toolz >=0.12.0,<1.0.0
     - typing_extensions
@@ -52,10 +53,13 @@ requirements:
 test:
   imports:
     - conda_lock
-  commands:
-    - pip check
+    - conda_lock.models
+    - conda_lock.src_parser
   requires:
     - pip
+  commands:
+    - pip check
+    - conda-lock --help
 
 about:
   home: https://github.com/conda-incubator/conda-lock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ test:
     - conda-lock --help
 
 about:
-  home: https://github.com/conda-incubator/conda-lock
+  home: https://github.com/conda/conda-lock
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -75,8 +75,8 @@ about:
     This also has the added benefit of acting as an external presolve for conda
     as the lockfiles it generates results in the conda solver not being invoked
     when installing the packages from the generated lockfile.
-  doc_url: https://conda-incubator.github.io/conda-lock
-  dev_url: https://github.com/conda-incubator/conda-lock
+  doc_url: https://conda.github.io/conda-lock/
+  dev_url: https://github.com/conda/conda-lock
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   host:
     - python
-    - hatch
+    - hatchling
     - hatch-requirements-txt
     - hatch-vcs
     - pip


### PR DESCRIPTION
Changelog: https://github.com/conda/conda-lock/releases
License: https://github.com/conda/conda-lock/blob/v1.4.0/LICENSE
Requirements:
- https://github.com/conda/conda-lock/blob/v1.4.0/pyproject.toml
- https://github.com/conda/conda-lock/blob/v1.4.0/requirements.txt

Actions:
1. Reset build number to 0
2. Skip py<36
3. Add --no-deps to script
4. Update host: add missing wheel, remove pinnings, remove setuptools-scm
5. Update run: add missing filelock >=3.8.0, add constraints for importlib-metadata >=1.7.0  # [py<38] and tomli  # [py<311]
6. Update test/imports: add conda_lock.models and conda_lock.src_parser
7. Add test command: conda-lock --help

Notes:
- conda-project requieres conda-lock
- you can test it by running `conda install -c sk_test hatch-requirements-txt cachecontrol-with-filecache click-default-group ensureconda conda-lock`