### PR TITLE
conda-lock 3.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/ruamel.yaml-feedstock/pr16/2908ac2
-  - https://staging.continuum.io/prefect/fs/ruamel.yaml.clib-feedstock/pr7/0935049

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/cachecontrol-feedstock/pr4/e871ca7
+  - https://staging.continuum.io/prefect/fs/ensureconda-feedstock/pr4/8f572f5
+  - https://staging.continuum.io/prefect/fs/keyring-feedstock/pr13/0d445e7

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/ensureconda-feedstock/pr4/8f572f5
-  - https://staging.continuum.io/prefect/fs/keyring-feedstock/pr13/0d445e7
-  - https://staging.continuum.io/prefect/fs/crashtest-feedstock/pr4/027f739
   - https://staging.continuum.io/prefect/fs/ruamel.yaml-feedstock/pr16/2908ac2
   - https://staging.continuum.io/prefect/fs/ruamel.yaml.clib-feedstock/pr7/0935049

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,5 @@ channels:
   - https://staging.continuum.io/prefect/fs/ensureconda-feedstock/pr4/8f572f5
   - https://staging.continuum.io/prefect/fs/keyring-feedstock/pr13/0d445e7
   - https://staging.continuum.io/prefect/fs/crashtest-feedstock/pr4/027f739
+  - https://staging.continuum.io/prefect/fs/ruamel.yaml-feedstock/pr16/2908ac2
+  - https://staging.continuum.io/prefect/fs/ruamel.yaml.clib-feedstock/pr7/0935049

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/ensureconda-feedstock/pr4/8f572f5
   - https://staging.continuum.io/prefect/fs/keyring-feedstock/pr13/0d445e7
+  - https://staging.continuum.io/prefect/fs/crashtest-feedstock/pr4/027f739

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - shellingham >=1.5,<2.0
     - trove-classifiers >=2022.5.19
     - xattr >=1.0.0,<2.0.0  # [osx]
-    - cachecontrol-with-filelock >=0.14.0,<0.15.0
+    - cachecontrol-with-filecache >=0.14.0,<0.15.0
     - crashtest >=0.4.1,<0.5.0
     - keyring >=25.1.0,<26.0.0
     - virtualenv >=20.26.6,<21.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.5.6" %}
+{% set version = "3.0.0" %}
 
 package:
   name: conda-lock
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/conda-lock/conda_lock-{{ version }}.tar.gz
-  sha256: 323db8b6438b46648c4ba4dab81547851ee8266dbe913680f7837c94cc5f1023
+  sha256: 2ec53330374060f7a5d66c615132706a154b349fa8c5811935640b7049fc9840
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - conda-lock = conda_lock:main
@@ -25,27 +25,39 @@ requirements:
     - python
     - click >=8.0
     - click-default-group
-    - ensureconda >=1.4.4
+    - ensureconda >=1.4.7
+    - filelock
     - gitpython >=3.1.30
     - jinja2
-    - pydantic >=1.10
+    - packaging >=24.0
+    - platformdirs >=3.10.0,<5.0.0
+    - pydantic >=2
     - pyyaml >=5.1
-    - tomli  # [py<311]
-    - typing_extensions
+    - requests >=2.26,<3.0
     - ruamel.yaml
-    - toolz >=0.12.0,<1.0.0
-    - cachecontrol-with-filecache >=0.12.9
-    - cachy >=0.3.0
-    - clikit >=0.6.2
-    - crashtest >=0.3.0
-    - html5lib >=1.0
-    - keyring >=21.2.0
-    - packaging >=20.4
-    - pkginfo >=1.4
-    - requests >=2.18
-    - tomlkit >=0.7.0
+    - semver >=3,<4
+    - setuptools
+    - tomli >=2.0.1,<3.0.0  # [py<311]
+    - tomlkit >=0.11.4,<1.0.0
+    - typing_extensions
+    - boltons >=23.0.0
+    - charset-normalizer
+    - zstandard >=0.15
+    - python-build >=1.2.1,<2.0.0
+    - dulwich >=0.22.6,<0.23.0
+    - python-fastjsonschema >=2.18.0,<3.0.0
+    - importlib-metadata >=4.4  # [py<310]
+    - python-installer >=0.7.0,<0.8.0
+    - pkginfo >=1.12,<2.0
+    - pyproject_hooks >=1.0.0,<2.0.0
+    - requests-toolbelt >=1.0.0,<2.0.0
+    - shellingham >=1.5,<2.0
+    - trove-classifiers >=2022.5.19
+    - xattr >=1.0.0,<2.0.0
+    - cachecontrol >=0.14.0,<0.15.0
+    - crashtest >=0.4.1,<0.5.0
+    - keyring >=25.1.0,<26.0.0
     - virtualenv >=20.0.26
-    - urllib3 >=1.26.5,<2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - requests-toolbelt >=1.0.0,<2.0.0
     - shellingham >=1.5,<2.0
     - trove-classifiers >=2022.5.19
-    - xattr >=1.0.0,<2.0.0
+    - xattr >=1.0.0,<2.0.0  # [osx]
     - cachecontrol >=0.14.0,<0.15.0
     - crashtest >=0.4.1,<0.5.0
     - keyring >=25.1.0,<26.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - click >=8.0
     - click-default-group
     - ensureconda >=1.4.7
-    - filelock
     - gitpython >=3.1.30
     - jinja2
     - packaging >=24.0
@@ -54,10 +53,10 @@ requirements:
     - shellingham >=1.5,<2.0
     - trove-classifiers >=2022.5.19
     - xattr >=1.0.0,<2.0.0  # [osx]
-    - cachecontrol >=0.14.0,<0.15.0
+    - cachecontrol-with-filelock >=0.14.0,<0.15.0
     - crashtest >=0.4.1,<0.5.0
     - keyring >=25.1.0,<26.0.0
-    - virtualenv >=20.0.26
+    - virtualenv >=20.26.6,<21.0.0
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8030](https://anaconda.atlassian.net/browse/PKG-8030)
- [Upstream repo](https://github.com/conda/conda-lock/tree/v3.0.0)
- release-diff: https://github.com/conda/conda-lock/compare/v2.5.6...v3.0.0
- requirements-tagged: https://github.com/conda/conda-lock/blob/v3.0.0/pyproject.toml


### Explanation of changes:

- Skip py<39
- Update runtime dependencies

### Notes:

- After testing `ruamel.yaml`'s downstream packages, it was found that `conda-lock` is not compatible with py313:
```
conda-lock                     2.5.6 py310hca03da5_0  pkgs/main
conda-lock                     2.5.6 py311hca03da5_0  pkgs/main
conda-lock                     2.5.6 py312hca03da5_0  pkgs/main
conda-lock                     2.5.6  py38hca03da5_0  pkgs/main
conda-lock                     2.5.6  py39hca03da5_0  pkgs/main
```
 see also https://github.com/AnacondaRecipes/ruamel.yaml-feedstock/pull/16#issuecomment-2812089414

[PKG-8030]: https://anaconda.atlassian.net/browse/PKG-8030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ