### PR TITLE
conda-lock 4.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.4" %}
+{% set version = "4.0.0" %}
 
 package:
   name: conda-lock
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/c/conda-lock/conda_lock-{{ version }}.tar.gz
-  sha256: 7ba6f8067834b3aae8662ed6316c5f15def431f129ddf423f7957c6181523db6
+  sha256: 050305a490861baa98d6c3876ed7b394707a67587d939548aac5e20b91b41d36
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12546](https://anaconda.atlassian.net/browse/PKG-12546)
- [Upstream repository](https://github.com/conda/conda-lock/tree/v4.0.0)
- [Upstream changelog/diff](https://github.com/conda/conda-lock/releases)

### Explanation of changes:

- New version number


[PKG-12546]: https://anaconda.atlassian.net/browse/PKG-12546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ